### PR TITLE
Change variable interpolation to ${var} format

### DIFF
--- a/properties/p.py
+++ b/properties/p.py
@@ -79,7 +79,7 @@ class Property:
         else:
             val = key
 
-        evalset = set(re.findall(r'(?<={)[^}]*(?=})', val))
+        evalset = set(re.findall(r'(?<=${)[^}]*(?=})', val))
 
         try:
             # If the set is empty. This is the final value. return it


### PR DESCRIPTION
Variable interpolation in .properties files works by changing substrings with
substituting ${variable_name}, not {variable_name}.

Feel free to disagree, but I couldn't find any references to the {} format.