### PR TITLE
fix: do not match {}, only ${}

### DIFF
--- a/properties/p.py
+++ b/properties/p.py
@@ -82,7 +82,7 @@ class Property:
         else:
             val = key
 
-        evalset = set(re.findall(r'(?<={)[^}]*(?=})', val))
+        evalset = set(re.findall(r'(?<=\${)[^}]*(?=})', val))
 
         try:
             # If the set is empty. This is the final value. return it


### PR DESCRIPTION
Pull request #2 was right in principle, but contained a syntax error ($ must be escaped in a RE)

if you add the following line to your test file, you can see what is the effect with or without this patch

```
file-format-template = /data/system/{os}/object/{obj-id}/
```